### PR TITLE
chore: Drop license.txt in favour of LICENSE file

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,1 +1,0 @@
-License: None


### PR DESCRIPTION
license.txt file was misleading stating the project was unlicensed however LICENSE states AGPLv3