### PR TITLE
Refactor: use app_logo if app_logo_url is not present in installed apps

### DIFF
--- a/commit/api/code_analysis.py
+++ b/commit/api/code_analysis.py
@@ -9,20 +9,23 @@ def get_name_of_app(organization, repo):
     '''
     Get name of app from repo
     '''
-    type = None
+    file_type = None
     app_name = None
     root_files = get_all_files_in_repo(access_token, organization, repo)
+    if type(root_files) == dict and root_files.get("message", "") == "Not Found":
+        return frappe.throw(f'Repository {repo} not found in organization {organization}')
+         
     for file in root_files:
         if file["name"] == "pyproject.toml":
-            type = "pyproject.toml"
+            file_type = "pyproject.toml"
             break
         elif file["name"] == "setup.py":
-            type = "setup.py"
+            file_type = "setup.py"
             break
     
-    if type == "pyproject.toml":
+    if file_type == "pyproject.toml":
         app_name = get_app_name_from_pyproject_toml(organization, repo)
-    elif type == "setup.py":
+    elif file_type == "setup.py":
         app_name = get_app_name_from_setup_py(organization, repo)   
 
     return app_name

--- a/commit/api/meta_data.py
+++ b/commit/api/meta_data.py
@@ -3,6 +3,13 @@ from commit.commit.code_analysis.apis import find_all_occurrences_of_whitelist
 
 @frappe.whitelist()
 def get_installed_apps():
+    '''
+        Get all installed apps
+        1. Get the installed applications from the Installed Applications doctype
+        2. Get the app hooks for each app
+        3. Get the app description, publisher, logo, version and git branch
+        4. Return the updated apps
+    '''
     install_app_doc = frappe.get_cached_doc('Installed Applications')
     install_apps = install_app_doc.get('installed_applications')
     updated_apps = []
@@ -18,7 +25,7 @@ def get_installed_apps():
         if app_publisher is not None:
             app_publisher = app_publisher[0]
         
-        app_logo_url = app_hooks.get('app_logo_url')
+        app_logo_url = app_hooks.get('app_logo_url') or app_hooks.get('app_logo')
         if app_logo_url is not None:
             app_logo_url = app_logo_url[0]
         


### PR DESCRIPTION
Note: before we only using app_logo_url as project logo from hooks.py for installed application of site, now if app_logo_url is not present then use app_logo
here in screenshot frappe logo is app_logo_url but raven is app_logo
<img width="1499" alt="image" src="https://github.com/user-attachments/assets/74d371de-89a2-4c2d-b7ba-130af41cca48">
