### PR TITLE
update readme because it was really needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
-# commit
-## commit
+# [commit](https://commit.frappe.cloud/)
 
-The Commit Company
+Born out of a need to improve developer tooling for Frappe, "Commit" allows you to visualize your app's database schema and view all it's APIs - improving developer productivity and security of your critical applications.
+
+## Basic Installation
+
+The below guide assumes that you already have a working Frappe and Bench installation. If you do not have it, then please head over to [Official Installation Guide](https://frappeframework.com/docs/user/en/installation).
+
+Go ahead and create a fresh new bench
+
+- `bench init commit`
+- `bench get-app https://github.com/The-commit-company/commit`
+- `bench new-site <preferred-site-url>`
+- `bench --site <site-url> install-app commit`
+
+Commit will now be accessible on https://<site-url>:8000/commit. 


### PR DESCRIPTION
I think some installation guide was very much needed. Because out of practice the first time when I was using commit, I had no clue that it was there on `/commit`. Later, when I was playing around, I realized that it should be on `/commit`. :) 