### PR TITLE
fix: API params are correctly extracted

### DIFF
--- a/commit/commit/code_analysis/apis.py
+++ b/commit/commit/code_analysis/apis.py
@@ -185,10 +185,10 @@ def get_api_name(file_content: str, index: int):
     def_index = file_content.find('def ', index)
 
     # Find occurrence of ":" after the def_index
-    colon_index = file_content.find(':', def_index)
+    colon_index = file_content.find('):', def_index)
 
     # Get the string between def_index and colon_index
-    api_def = file_content[def_index:colon_index].replace('\n', '').replace('\t', '')
+    api_def = file_content[def_index:colon_index+1].replace('\n', '').replace('\t', '')
 
     # api_def is of the form "def api_name(self, arg1, arg2, ...)"
     # We need to get the api_name. To do this, we can remove the "def " first


### PR DESCRIPTION
Earlier, the logic to find the function definition string was to go from the first mention of "def" to the first mention of ":" after the def index.

With type annotations, this means that a function like this
```py
def add(a: int, b:int):

  #Add logic here
```

would give a function def like: `add(a` which is incorrect.

Two changes made:
1. For the ending index, look for `):` instead of just the colon since that will signal the end of the function definition. 
2. API Def is extracted until the last index of "):" + 1 to cover the last character.

This ensures that all params are covered.