### PR TITLE
feat: add openapi support

### DIFF
--- a/commit/api/api_explorer.py
+++ b/commit/api/api_explorer.py
@@ -11,7 +11,7 @@ def get_apis_for_project(project_branch: str):
     """
     Gets the Project Branch document with the organization and app name
     """
-    branch_doc = frappe.get_doc("Commit Project Branch", project_branch)
+    branch_doc = frappe.get_cached_doc("Commit Project Branch", project_branch)
 
     apis = (
         json.loads(branch_doc.whitelisted_apis).get("apis", [])
@@ -81,7 +81,7 @@ def get_file_content_from_path(
     Gets the Project Branch document with the organization and app name
     """
     if viewer_type == "project":
-        branch_doc = frappe.get_doc("Commit Project Branch", project_branch)
+        branch_doc = frappe.get_cached_doc("Commit Project Branch", project_branch)
 
         api_data = json.loads(branch_doc.whitelisted_apis)["apis"]
     else:

--- a/commit/api/convert_to_webp.py
+++ b/commit/api/convert_to_webp.py
@@ -40,7 +40,7 @@ def convert_to_webp(
             "File", filters={"file_url": file_url}, fields=["name"], limit=1
         )
         if files:
-            _file = frappe.get_doc("File", files[0].name)
+            _file = frappe.get_cached_doc("File", files[0].name)
             webp_path = _file.get_full_path().replace(extn, "webp")
             convert_and_save_image(image, webp_path)
             new_file = frappe.copy_doc(_file)
@@ -57,7 +57,7 @@ def convert_to_webp(
         filename = image_url.split("/")[-1]
         extn = get_extension(filename)
         if can_convert_image(extn):
-            _file = frappe.get_doc(
+            _file = frappe.get_cached_doc(
                 {
                     "doctype": "File",
                     "file_name": f"{filename.replace(extn, 'webp')}",

--- a/commit/api/generate_documentation.py
+++ b/commit/api/generate_documentation.py
@@ -202,7 +202,7 @@ def save_documentation_for_project_branch(
     project_branch: str, endpoint: str, documentation: str
 ):
 
-    doc = frappe.get_doc("Commit Project Branch", project_branch)
+    doc = frappe.get_cached_doc("Commit Project Branch", project_branch)
     docs = json.loads(doc.documentation) if doc.documentation else {}
     apis = docs.get("apis", [])
 
@@ -237,7 +237,7 @@ def save_documentation_for_site_app(
 ):
 
     if frappe.db.exists("Commit Branch Documentation", project_branch):
-        doc = frappe.get_doc("Commit Branch Documentation", project_branch)
+        doc = frappe.get_cached_doc("Commit Branch Documentation", project_branch)
         docs = json.loads(doc.documentation) if doc.documentation else {}
         apis = docs.get("apis", [])
 

--- a/commit/api/openapi.py
+++ b/commit/api/openapi.py
@@ -201,16 +201,26 @@ def _build_openapi_document(
         "Automatically generated OpenAPI definition for Frappe whitelisted methods."
     )
     base_url = _get_request_base_url()
+    paths = _build_paths_from_apis(apis)
 
-    return {
+    # Ensure version is a string for strict OpenAPI validators (e.g. Postman).
+    try:
+        version = frappe.get_hooks().get("app_version", ["0.0.0"])
+        version = version[0] if version else "0.0.0"
+    except Exception:
+        version = "0.0.0"
+    if not isinstance(version, str):
+        version = "0.0.0"
+
+    doc = {
         "openapi": "3.0.0",
         "info": {
             "title": title or default_title,
-            "version": frappe.get_hooks().get("app_version", ["0.0.0"])[0],
+            "version": version,
             "description": description or default_description,
         },
         "servers": [{"url": base_url, "description": "Frappe site"}],
-        "paths": _build_paths_from_apis(apis),
+        "paths": paths,
         "components": {
             "securitySchemes": {
                 "UserKey": {
@@ -221,8 +231,10 @@ def _build_openapi_document(
                 }
             }
         },
-        "security": [{"UserKey": []}],
     }
+    # Do not set document-level security so Postman/other tools don't send auth by default.
+    # Guest endpoints work without it; protected endpoints can add auth in the tool.
+    return doc
 
 
 @frappe.whitelist(allow_guest=True)

--- a/commit/api/openapi.py
+++ b/commit/api/openapi.py
@@ -1,0 +1,279 @@
+import json
+from collections import Counter
+
+import frappe
+
+from commit.commit.code_analysis.apis import find_all_occurrences_of_whitelist
+
+
+def _python_type_to_openapi_type(type_hint: str) -> dict:
+    """
+    Map a simple Python type hint string to an OpenAPI schema.
+    Falls back to string when unsure.
+    """
+    if not type_hint:
+        return {"type": "string"}
+
+    normalized = type_hint.strip().lower()
+
+    if normalized in {"int", "integer"}:
+        return {"type": "integer"}
+    if normalized in {"float", "decimal"}:
+        return {"type": "number", "format": "float"}
+    if normalized in {"bool", "boolean"}:
+        return {"type": "boolean"}
+    if normalized in {"list", "tuple", "set"}:
+        return {"type": "array", "items": {"type": "string"}}
+    if normalized in {"dict", "mapping"}:
+        return {"type": "object"}
+
+    return {"type": "string"}
+
+
+def _get_duplicate_api_names(apis: list) -> set:
+    """Return set of API names that appear more than once (so we can disambiguate summary)."""
+    names = [api.get("name") or "" for api in apis if api.get("api_path")]
+    counts = Counter(names)
+    return {n for n, c in counts.items() if c > 1}
+
+
+def _summary_for_api(api: dict, duplicate_names: set) -> str:
+    """Unique summary: name, or 'name - (module)' when name is duplicate."""
+    name = api.get("name") or api.get("api_path") or ""
+    if not name:
+        return api.get("api_path", "")
+    if name not in duplicate_names:
+        return name
+    # Disambiguate with module path (api_path without last segment). Use one separator
+    # to avoid " - (module)" becoming " - -module-" when tools sanitize for file names.
+    api_path = api.get("api_path", "")
+    parts = api_path.rsplit(".", 1)
+    file_name = parts[0] if len(parts) == 2 else api_path
+    return f"{name} · {file_name}"
+
+
+def _build_operation_for_api(api: dict, duplicate_names: set | None = None) -> dict:
+    """
+    Build the OpenAPI operation object for a single API (summary, parameters, responses, security).
+    Returns the operation dict that can be placed under a path and method (get, post, etc.).
+    """
+    duplicate_names = duplicate_names or set()
+    api_path = api.get("api_path", "")
+    arguments = api.get("arguments") or []
+    documentation = api.get("documentation") or ""
+
+    parameters = []
+    for arg in arguments:
+        name = arg.get("argument")
+        if not name or name in {"self", "cls"}:
+            continue
+        schema = _python_type_to_openapi_type(arg.get("type", ""))
+        required = arg.get("default", "") == ""
+        parameters.append(
+            {
+                "name": name,
+                "in": "query",
+                "required": required,
+                "schema": schema,
+            }
+        )
+
+    summary = _summary_for_api(api, duplicate_names)
+    operation = {
+        "summary": summary,
+        "description": documentation or "",
+        "operationId": api_path.replace(".", "_"),
+        "parameters": parameters,
+        "responses": {
+            "200": {
+                "description": "Successful response",
+            }
+        },
+    }
+    if api.get("allow_guest"):
+        operation["security"] = []
+
+    return operation
+
+
+def _build_path_item_for_api(
+    api: dict, duplicate_names: set | None = None
+) -> tuple[str, dict]:
+    """
+    Build the OpenAPI path and path-item (method -> operation) for a single API.
+    Returns (path_string, path_item) where path_item is e.g. {"get": {...}, "post": {...}}.
+    """
+    api_path = api.get("api_path")
+    if not api_path:
+        return "", {}
+
+    path = f"/api/method/{api_path}"
+    request_types = api.get("request_types") or ["GET"]
+    operation = _build_operation_for_api(api, duplicate_names)
+    path_item = {}
+    for method in request_types:
+        method_lower = (method or "GET").lower()
+        if method_lower not in path_item:
+            path_item[method_lower] = dict(operation)
+    return path, path_item
+
+
+def get_openapi_for_single_api(api: dict) -> dict:
+    """
+    Return the OpenAPI paths object for a single API.
+    Use this to get the OpenAPI representation of one whitelisted API (e.g. to expose or merge elsewhere).
+    """
+    path, path_item = _build_path_item_for_api(api)
+    if not path:
+        return {}
+    return {path: path_item}
+
+
+def _build_paths_from_apis(apis: list) -> dict:
+    """
+    Build OpenAPI paths from Commit's internal API discovery objects.
+    One pass to find duplicate API names; summaries become 'name - (module)' only when duplicated.
+    """
+    duplicate_names = _get_duplicate_api_names(apis)
+    paths: dict = {}
+    for api in apis:
+        path, path_item = _build_path_item_for_api(api, duplicate_names)
+        if not path:
+            continue
+        if path not in paths:
+            paths[path] = {}
+        for method_lower, operation in path_item.items():
+            if method_lower in paths[path]:
+                continue
+            paths[path][method_lower] = operation
+    return paths
+
+
+def _get_apis_from_project_branch(project_branch: str) -> list:
+    """
+    Collect API definitions for a single Commit Project Branch (from stored whitelisted_apis).
+    """
+    branch_doc = frappe.get_cached_doc("Commit Project Branch", project_branch)
+    apis = (
+        json.loads(branch_doc.whitelisted_apis).get("apis", [])
+        if branch_doc.whitelisted_apis
+        else []
+    )
+    documentation = (
+        json.loads(branch_doc.documentation).get("apis", [])
+        if branch_doc.documentation
+        else []
+    )
+    for api in apis:
+        for doc in documentation:
+            if isinstance(doc, str):
+                try:
+                    doc = json.loads(doc)
+                except json.JSONDecodeError:
+                    continue
+            if doc.get("function_name") == api.get("name") and doc.get(
+                "path"
+            ) == api.get("api_path"):
+                api["documentation"] = doc.get("documentation")
+                break
+    return apis
+
+
+def _get_request_base_url() -> str:
+    """Return the current request's base URL (scheme + host) so the OpenAPI spec has a default server."""
+    try:
+        return frappe.utils.get_url().rstrip("/")
+    except Exception:
+        return "https://your-frappe-site.com"
+
+
+def _build_openapi_document(
+    apis: list,
+    title: str | None = None,
+    description: str | None = None,
+) -> dict:
+    """
+    Build a minimal OpenAPI 3.0 document from Commit's API discovery data.
+    """
+    site_name = frappe.local.site if getattr(frappe.local, "site", None) else "Commit"
+    default_title = f"Commit API - {site_name}"
+    default_description = (
+        "Automatically generated OpenAPI definition for Frappe whitelisted methods."
+    )
+    base_url = _get_request_base_url()
+
+    return {
+        "openapi": "3.0.0",
+        "info": {
+            "title": title or default_title,
+            "version": frappe.get_hooks().get("app_version", ["0.0.0"])[0],
+            "description": description or default_description,
+        },
+        "servers": [{"url": base_url, "description": "Frappe site"}],
+        "paths": _build_paths_from_apis(apis),
+        "components": {
+            "securitySchemes": {
+                "UserKey": {
+                    "type": "apiKey",
+                    "in": "header",
+                    "name": "Authorization",
+                    "description": "Frappe user API key / token or session cookie.",
+                }
+            }
+        },
+        "security": [{"UserKey": []}],
+    }
+
+
+@frappe.whitelist(allow_guest=True)
+def get_openapi_definition_installed_apps(app_name: str | None = None) -> dict:
+    """
+    Return an OpenAPI 3.0 definition for Installed Apps only.
+
+    - When app_name is provided, only that app's whitelisted APIs are included.
+    - When app_name is omitted, all installed apps on the current site are included.
+
+    Use this for APIs discovered from apps in Installed Applications.
+    """
+    if not app_name:
+        frappe.throw("App name is required.")
+
+    app_path = frappe.get_app_path(app_name)
+    if not app_path:
+        frappe.throw(f"App {app_name} is not installed on this site.")
+    root_path = app_path.rsplit("/", 1)[0]
+    apis = find_all_occurrences_of_whitelist(root_path, app_name)
+    title = f"{app_name}'s OpenAPI Definition"
+
+    return _build_openapi_document(
+        apis,
+        title=title,
+        description=f"OpenAPI definition for whitelisted methods for {app_name}.",
+    )
+
+
+@frappe.whitelist(allow_guest=True)
+def get_openapi_definition_project_apps(project_branch: str | None = None) -> dict:
+    """
+    Return an OpenAPI 3.0 definition for Project Apps (Commit Project Branch) only.
+
+    - When project_branch is provided, only that branch's APIs are included.
+    - When project_branch is omitted, all Commit Project Branch documents on the site are included.
+
+    Use this for APIs from project branches (stored whitelisted_apis).
+    """
+    if not project_branch:
+        frappe.throw("Project branch is required.")
+
+    if not frappe.db.exists("Commit Project Branch", project_branch):
+        frappe.throw(f"Project branch {project_branch} does not exist.")
+
+    project_branch_doc = frappe.get_cached_doc("Commit Project Branch", project_branch)
+    apis = _get_apis_from_project_branch(project_branch)
+    title = f"{project_branch_doc.app_name}'s OpenAPI Definition"
+
+    return _build_openapi_document(
+        apis,
+        title=title,
+        description=f"OpenAPI definition for whitelisted methods for {project_branch_doc.app_name} ({project_branch_doc.branch_name}).",
+    )

--- a/commit/api/preview.py
+++ b/commit/api/preview.py
@@ -39,7 +39,7 @@ def save_preview_screenshot(url, doctype, docname, field):
     # ✅ Correct way: Wrap bytes in BytesIO
     screenshot_io = io.BytesIO(screenshot_bytes)
 
-    file_doc = frappe.get_doc(
+    file_doc = frappe.get_cached_doc(
         {
             "doctype": "File",
             "file_name": docname + "_" + "preview.png",
@@ -55,7 +55,7 @@ def save_preview_screenshot(url, doctype, docname, field):
     # Convert to WebP
     file_url = convert_to_webp(file_doc.file_url, file_doc)
     # Update the document with the preview file URL
-    doc = frappe.get_doc(doctype, docname)
+    doc = frappe.get_cached_doc(doctype, docname)
     doc.set(field, file_url)
     doc.save()
 

--- a/commit/commit/code_analysis/apis.py
+++ b/commit/commit/code_analysis/apis.py
@@ -404,6 +404,37 @@ def extract_name_from_def(api_def: str):
     return api_def.split("(")[0].strip()
 
 
+def _split_params_by_comma(params_str: str) -> list:
+    """
+    Split parameter string by top-level commas, ignoring commas inside [], (), {}.
+    """
+    parts = []
+    current = []
+    open_brackets = []  # stack of opening bracket chars
+    bracket_pairs = {"[": "]", "(": ")", "{": "}"}
+    i = 0
+    while i < len(params_str):
+        c = params_str[i]
+        if c in bracket_pairs:
+            open_brackets.append(c)
+            current.append(c)
+            i += 1
+        elif open_brackets and c == bracket_pairs[open_brackets[-1]]:
+            open_brackets.pop()
+            current.append(c)
+            i += 1
+        elif c == "," and not open_brackets:
+            parts.append("".join(current).strip())
+            current = []
+            i += 1
+        else:
+            current.append(c)
+            i += 1
+    if current:
+        parts.append("".join(current).strip())
+    return parts
+
+
 def extract_arguments_from_def(api_def: str):
     """
     Extract arguments from def
@@ -411,7 +442,8 @@ def extract_arguments_from_def(api_def: str):
     if "(" not in api_def or ")" not in api_def:
         arguments_with_types_defaults = []
     else:
-        arguments_with_types_defaults = api_def.split("(")[1].split(")")[0].split(",")
+        params_str = api_def.split("(")[1].split(")")[0]
+        arguments_with_types_defaults = _split_params_by_comma(params_str)
 
     arguments = []
     for arg in arguments_with_types_defaults:
@@ -420,14 +452,15 @@ def extract_arguments_from_def(api_def: str):
         argument = ""
         type = ""
         if "=" in argument_with_types_default:
-            default_split = argument_with_types_default.split("=")
+            default_split = argument_with_types_default.split("=", 1)
             default = default_split[1].strip().replace('"', "").replace("'", "")
             argument = default_split[0].strip()
         else:
             argument = argument_with_types_default
         if ":" in argument:
-            type = argument.split(":")[1].strip()
-            argument = argument.split(":")[0].strip()
+            name_type = argument.split(":", 1)
+            argument = name_type[0].strip()
+            type = name_type[1].strip()
         arguments.append({"argument": argument, "type": type, "default": default})
 
     return arguments
@@ -489,7 +522,9 @@ def get_documentation_from_branch_documentation(
     Get documentation from the Commit Branch Documentation
     """
     if frappe.db.exists("Commit Branch Documentation", app_name):
-        branch_documentation = frappe.get_doc("Commit Branch Documentation", app_name)
+        branch_documentation = frappe.get_cached_doc(
+            "Commit Branch Documentation", app_name
+        )
         docs = (
             json.loads(branch_documentation.documentation)
             if branch_documentation.documentation

--- a/commit/commit/doctype/commit_docs/commit_docs.py
+++ b/commit/commit/doctype/commit_docs/commit_docs.py
@@ -73,7 +73,7 @@ def get_docs_sidebar_parent_labels(id: str):
     """
 
     # Get the Commit Docs Document
-    commit_docs = frappe.get_doc("Commit Docs", id)
+    commit_docs = frappe.get_cached_doc("Commit Docs", id)
 
     parent_labels = []
 
@@ -107,7 +107,7 @@ def get_all_commit_docs_detail():
     commit_docs_obj = {}
 
     for commit_docs in all_commit_docs:
-        commit_docs = frappe.get_doc("Commit Docs", commit_docs.name).as_dict()
+        commit_docs = frappe.get_cached_doc("Commit Docs", commit_docs.name).as_dict()
 
         parse_doc = parse_commit_docs(commit_docs)
 
@@ -282,7 +282,7 @@ def get_sidebar_items(sidebar, show_hidden_items: bool = False):
         group_items = []
         for group_item in commit_docs_page.linked_pages:
             # Get the document for each linked page
-            group_commit_docs_page = frappe.get_doc(
+            group_commit_docs_page = frappe.get_cached_doc(
                 "Commit Docs Page", group_item.commit_docs_page
             )
 
@@ -340,7 +340,9 @@ def get_sidebar_items(sidebar, show_hidden_items: bool = False):
         if sidebar_item.hide_on_sidebar and not show_hidden_items:
             continue
 
-        commit_docs_page = frappe.get_doc("Commit Docs Page", sidebar_item.docs_page)
+        commit_docs_page = frappe.get_cached_doc(
+            "Commit Docs Page", sidebar_item.docs_page
+        )
 
         permitted = commit_docs_page.allow_guest or frappe.session.user != "Guest"
         published = commit_docs_page.published or frappe.session.user != "Guest"
@@ -386,7 +388,9 @@ def get_first_page_route(route: str):
         commit_docs = frappe.get_doc("Commit Docs", {"route": route})
         found = False
         for sidebar in commit_docs.sidebar:
-            commit_docs_page = frappe.get_doc("Commit Docs Page", sidebar.docs_page)
+            commit_docs_page = frappe.get_cached_doc(
+                "Commit Docs Page", sidebar.docs_page
+            )
             if commit_docs_page.published:
                 found = True
                 return commit_docs_page.route
@@ -440,7 +444,7 @@ def manage_sidebar(commit_doc: str, parent_labels, docs_page):
     """
 
     # Get the Commit Docs Document
-    doc = frappe.get_doc("Commit Docs", commit_doc)
+    doc = frappe.get_cached_doc("Commit Docs", commit_doc)
 
     # Loop Over the Parent Labels
     if isinstance(parent_labels, str):
@@ -497,7 +501,7 @@ def manage_navbar(commit_doc: str, navbar_items, sub_navbar_items=None):
     # 4. Save the Navbar Items
     """
 
-    doc = frappe.get_doc("Commit Docs", commit_doc)
+    doc = frappe.get_cached_doc("Commit Docs", commit_doc)
 
     if isinstance(navbar_items, str):
         navbar_items = json.loads(navbar_items)
@@ -573,7 +577,7 @@ def manage_footer(commit_doc: str, footer_columns, footer_items):
     # 5. Save the Footer Items
     """
 
-    doc = frappe.get_doc("Commit Docs", commit_doc)
+    doc = frappe.get_cached_doc("Commit Docs", commit_doc)
     if isinstance(footer_columns, str):
         footer_columns = json.loads(footer_columns)
 

--- a/commit/commit/doctype/commit_docs_page/commit_docs_page.py
+++ b/commit/commit/doctype/commit_docs_page/commit_docs_page.py
@@ -67,7 +67,7 @@ def publish_documentation(
     """
 
     # 1. Create a new Commit Docs Page Document
-    commit_docs_page = frappe.get_doc(
+    commit_docs_page = frappe.get_cached_doc(
         {
             "doctype": "Commit Docs Page",
             "title": title,
@@ -81,7 +81,7 @@ def publish_documentation(
 
     # 2. Update the Commit Docs Document with the new Page by adding it to the Sidebar child table
 
-    commit_docs = frappe.get_doc("Commit Docs", docs_name)
+    commit_docs = frappe.get_cached_doc("Commit Docs", docs_name)
 
     commit_docs.append(
         "sidebar", {"parent_label": parent_label, "docs_page": commit_docs_page.name}
@@ -93,7 +93,9 @@ def publish_documentation(
 
     if viewer_type == "project":
         # Get the Project Branch Document
-        project_branch_doc = frappe.get_doc("Commit Project Branch", project_branch)
+        project_branch_doc = frappe.get_cached_doc(
+            "Commit Project Branch", project_branch
+        )
 
         # Get the documentation JSON
         documentation = (
@@ -120,7 +122,7 @@ def publish_documentation(
                 project_branch_doc.save()
 
     else:
-        commit_branch_documentation = frappe.get_doc(
+        commit_branch_documentation = frappe.get_cached_doc(
             "Commit Branch Documentation", project_branch
         )
 
@@ -279,7 +281,7 @@ def create_commit_docs_page(data):
         data = json.loads(data)
 
     # create a new Commit Docs Page
-    commit_docs_page = frappe.get_doc(
+    commit_docs_page = frappe.get_cached_doc(
         {
             "doctype": "Commit Docs Page",
             "title": data.get("title"),
@@ -290,7 +292,7 @@ def create_commit_docs_page(data):
     commit_docs_page.insert()
 
     if data.get("sidebar_label"):
-        commit_doc = frappe.get_doc("Commit Docs", data.get("commit_docs"))
+        commit_doc = frappe.get_cached_doc("Commit Docs", data.get("commit_docs"))
         commit_doc.append(
             "sidebar",
             {

--- a/commit/commit/doctype/commit_project_branch/commit_project_branch.py
+++ b/commit/commit/doctype/commit_project_branch/commit_project_branch.py
@@ -66,11 +66,11 @@ class CommitProjectBranch(Document):
             os.mkdir(self.path_to_folder)
 
     def get_path_to_folder(self):
-        project = frappe.get_doc("Commit Project", self.project)
+        project = frappe.get_cached_doc("Commit Project", self.project)
         return project.path_to_folder + "/" + self.branch_name
 
     def clone_repo(self):
-        project = frappe.get_doc("Commit Project", self.project)
+        project = frappe.get_cached_doc("Commit Project", self.project)
         self.app_name = project.app_name
         repo_url = "https://github.com/{}/{}".format(project.org, project.repo_name)
 
@@ -200,7 +200,7 @@ def get_code_from_file(file_path: str, block_start: int, block_end: int):
 
 def background_fetch_process(project_branch):
     try:
-        doc = frappe.get_doc("Commit Project Branch", project_branch)
+        doc = frappe.get_cached_doc("Commit Project Branch", project_branch)
         frappe.publish_realtime(
             "commit_branch_clone_repo",
             {
@@ -285,10 +285,10 @@ def background_fetch_process(project_branch):
 @frappe.whitelist(allow_guest=True)
 def fetch_repo(doc, name=None):
     if name:
-        project_branch = frappe.get_doc("Commit Project Branch", name)
+        project_branch = frappe.get_cached_doc("Commit Project Branch", name)
     else:
         doc = json.loads(doc)
-        project_branch = frappe.get_doc("Commit Project Branch", doc.get("name"))
+        project_branch = frappe.get_cached_doc("Commit Project Branch", doc.get("name"))
     project_branch.fetch_repo()
     project_branch.save()
     return "Hello"
@@ -305,7 +305,7 @@ def generate_branch_documentation(project_branch):
         user=frappe.session.user,
     )
 
-    doc = frappe.get_doc("Commit Project Branch", project_branch)
+    doc = frappe.get_cached_doc("Commit Project Branch", project_branch)
     doc.get_whitelisted_apis_code()
     doc.save()
 
@@ -327,6 +327,6 @@ def get_module_doctype_map_for_branches(branches: str):
     branches = json.loads(branches)
     module_doctypes_map = {}
     for branch in branches:
-        project_branch = frappe.get_doc("Commit Project Branch", branch)
+        project_branch = frappe.get_cached_doc("Commit Project Branch", branch)
         module_doctypes_map[branch] = json.loads(project_branch.module_doctypes_map)
     return module_doctypes_map

--- a/commit/commit/doctype/github_settings/github_settings.py
+++ b/commit/commit/doctype/github_settings/github_settings.py
@@ -32,7 +32,7 @@ def get_access_token(code):
     1. Make a POST request to GitHub to get the access token
     2. Return the access token
     """
-    github_settings = frappe.get_doc("Github Settings")
+    github_settings = frappe.get_cached_doc("Github Settings")
     client_id = github_settings.client_id
     client_secret = github_settings.get_password("client_secret")
     token_url = github_settings.token_uri

--- a/commit/fixtures/server_script.json
+++ b/commit/fixtures/server_script.json
@@ -15,7 +15,7 @@
   "rate_limit_count": 5,
   "rate_limit_seconds": 86400,
   "reference_doctype": null,
-  "script": "commit_branches_daily = frappe.get_list(\"Commit Project Branch\", filters={\"frequency\": \"Daily\"}, pluck='name')\n\nfor branch in commit_branches_daily :\n    branch_doc = frappe.get_doc(\"Commit Project Branch\", branch)\n    branch_doc.fetch_repo()\n    branch_doc.save()\n    \nfrappe.db.commit()",
+  "script": "commit_branches_daily = frappe.get_list(\"Commit Project Branch\", filters={\"frequency\": \"Daily\"}, pluck='name')\n\nfor branch in commit_branches_daily :\n    branch_doc = frappe.get_cached_doc(\"Commit Project Branch\", branch)\n    branch_doc.fetch_repo()\n    branch_doc.save()\n    \nfrappe.db.commit()",
   "script_type": "Scheduler Event"
  },
  {
@@ -34,7 +34,7 @@
   "rate_limit_count": 5,
   "rate_limit_seconds": 86400,
   "reference_doctype": null,
-  "script": "commit_branches_weekly = frappe.get_list(\"Commit Project Branch\", filters={\"frequency\" : \"Weekly\"}, pluck=\"name\")\n\n\nfor branch in commit_branches_weekly:\n    branch_doc = frappe.get_doc(\"Commit Project Branch\", branch)\n    branch_doc.fetch_repo()\n    branch_doc.save()\n\nfrappe.db.commit()",
+  "script": "commit_branches_weekly = frappe.get_list(\"Commit Project Branch\", filters={\"frequency\" : \"Weekly\"}, pluck=\"name\")\n\n\nfor branch in commit_branches_weekly:\n    branch_doc = frappe.get_cached_doc(\"Commit Project Branch\", branch)\n    branch_doc.fetch_repo()\n    branch_doc.save()\n\nfrappe.db.commit()",
   "script_type": "Scheduler Event"
  },
  {
@@ -53,7 +53,7 @@
   "rate_limit_count": 5,
   "rate_limit_seconds": 86400,
   "reference_doctype": null,
-  "script": "commit_branches_monthly = frappe.get_list(\"Commit Project Branch\", filters={\"frequency\" : \"Monthly\"}, pluck = \"name\")\n\nfor branch in commit_branches_monthly:\n    branch_doc = frappe.get_doc(\"Commit Project Branch\", branch)\n    branch_doc.fetch_repo()\n    branch_doc.save()\n\nfrappe.db.commit()",
+  "script": "commit_branches_monthly = frappe.get_list(\"Commit Project Branch\", filters={\"frequency\" : \"Monthly\"}, pluck = \"name\")\n\nfor branch in commit_branches_monthly:\n    branch_doc = frappe.get_cached_doc(\"Commit Project Branch\", branch)\n    branch_doc.fetch_repo()\n    branch_doc.save()\n\nfrappe.db.commit()",
   "script_type": "Scheduler Event"
  }
 ]

--- a/commit/utils/api_analysis.py
+++ b/commit/utils/api_analysis.py
@@ -109,11 +109,46 @@ def extract_name_from_def(api_def: str):
     return api_def.split("(")[0].strip()
 
 
+def _split_params_by_comma(params_str: str) -> list:
+    """
+    Split parameter string by top-level commas, ignoring commas inside [], (), {}.
+    """
+    parts = []
+    current = []
+    open_brackets = []  # stack of opening bracket chars
+    bracket_pairs = {"[": "]", "(": ")", "{": "}"}
+    i = 0
+    while i < len(params_str):
+        c = params_str[i]
+        if c in bracket_pairs:
+            open_brackets.append(c)
+            current.append(c)
+            i += 1
+        elif open_brackets and c == bracket_pairs[open_brackets[-1]]:
+            open_brackets.pop()
+            current.append(c)
+            i += 1
+        elif c == "," and not open_brackets:
+            parts.append("".join(current).strip())
+            current = []
+            i += 1
+        else:
+            current.append(c)
+            i += 1
+    if current:
+        parts.append("".join(current).strip())
+    return parts
+
+
 def extract_arguments_from_def(api_def: str):
     """
     Extract arguments from def
     """
-    arguments_with_types_defaults = api_def.split("(")[1].split(")")[0].split(",")
+    if "(" not in api_def or ")" not in api_def:
+        arguments_with_types_defaults = []
+    else:
+        params_str = api_def.split("(")[1].split(")")[0]
+        arguments_with_types_defaults = _split_params_by_comma(params_str)
 
     arguments = []
     for arg in arguments_with_types_defaults:
@@ -122,14 +157,15 @@ def extract_arguments_from_def(api_def: str):
         argument = ""
         type = ""
         if "=" in argument_with_types_default:
-            default_split = argument_with_types_default.split("=")
+            default_split = argument_with_types_default.split("=", 1)
             default = default_split[1].strip().replace('"', "").replace("'", "")
             argument = default_split[0].strip()
         else:
             argument = argument_with_types_default
         if ":" in argument:
-            type = argument.split(":")[1].strip()
-            argument = argument.split(":")[0].strip()
+            name_type = argument.split(":", 1)
+            argument = name_type[0].strip()
+            type = name_type[1].strip()
         arguments.append({"argument": argument, "type": type, "default": default})
 
     return arguments

--- a/dashboard/src/components/features/api_viewer/APIList.tsx
+++ b/dashboard/src/components/features/api_viewer/APIList.tsx
@@ -1,6 +1,15 @@
 import { Button } from "@/components/ui/button"
-import { Dialog, DialogTrigger } from "@/components/ui/dialog"
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { APIData } from "@/types/APIData"
 import { useEffect, useMemo, useRef, useState } from "react"
@@ -22,12 +31,22 @@ export interface APIListProps {
     project_branch?: string
 }
 
+const getDefaultBaseUrl = () => web_url.replace(/\/$/, "")
+
 const APIList = ({ apiList, app_name, branch_name, setSelectedEndpoint, selectedEndpoint, path_to_folder, listRef, viewerType = 'app', project_branch }: APIListProps) => {
     const [searchQuery, setSearchQuery] = useState<string>('')
     const [requestTypeFilter, setRequestTypeFilter] = useState<string>('All')
     const [openApiLoading, setOpenApiLoading] = useState(false)
+    const [openApiDialogOpen, setOpenApiDialogOpen] = useState(false)
+    const [openApiBaseUrl, setOpenApiBaseUrl] = useState("")
 
-    const handleDownloadOpenAPI = async () => {
+    useEffect(() => {
+        if (openApiDialogOpen) {
+            setOpenApiBaseUrl(viewerType === "app" ? getDefaultBaseUrl() : "")
+        }
+    }, [openApiDialogOpen, viewerType])
+
+    const handleDownloadOpenAPI = async (baseUrl: string) => {
         const isProject = viewerType === 'project' && project_branch
         const method = isProject
             ? 'commit.api.openapi.get_openapi_definition_project_apps'
@@ -42,12 +61,17 @@ const APIList = ({ apiList, app_name, branch_name, setSelectedEndpoint, selected
             const res = await fetch(url)
             const json = await res.json()
             const spec = json?.message ?? json
+            const serverUrl = baseUrl.trim().replace(/\/$/, "") || getDefaultBaseUrl()
+            if (spec && typeof spec === "object") {
+                spec.servers = [{ url: serverUrl, description: "Frappe site" }]
+            }
             const blob = new Blob([JSON.stringify(spec, null, 2)], { type: 'application/json' })
             const a = document.createElement('a')
             a.href = URL.createObjectURL(blob)
-            a.download = `${app_name}-${project_branch}-openapi.json`
+            a.download = `${app_name}-${project_branch ?? "app"}-openapi.json`
             a.click()
             URL.revokeObjectURL(a.href)
+            setOpenApiDialogOpen(false)
         } finally {
             setOpenApiLoading(false)
         }
@@ -93,16 +117,50 @@ const APIList = ({ apiList, app_name, branch_name, setSelectedEndpoint, selected
                     </div>
                 </div>
                 <div className="flex items-center gap-1">
-                    <Button
-                        aria-label="Download OpenAPI spec"
-                        size="sm"
-                        variant="outline"
-                        onClick={handleDownloadOpenAPI}
-                        disabled={openApiLoading}
-                    >
-                        <FileJson className="h-4 w-4 mr-2" />
-                         OpenAPI
-                    </Button>
+                    <Dialog open={openApiDialogOpen} onOpenChange={setOpenApiDialogOpen}>
+                        <DialogTrigger asChild>
+                            <Button
+                                aria-label="Download OpenAPI spec"
+                                size="sm"
+                                variant="outline"
+                            >
+                                <FileJson className="h-4 w-4 mr-2" />
+                                OpenAPI
+                            </Button>
+                        </DialogTrigger>
+                        <DialogContent className="sm:max-w-md">
+                            <DialogHeader>
+                                <DialogTitle>Download OpenAPI spec</DialogTitle>
+                                <DialogDescription>
+                                    Set the base URL for the API. It will be used in the spec as the default server so tools like Bruno use the correct domain.
+                                </DialogDescription>
+                            </DialogHeader>
+                            <div className="grid gap-2 py-2">
+                                <Label htmlFor="openapi-base-url">Base URL</Label>
+                                <Input
+                                    id="openapi-base-url"
+                                    type="url"
+                                    placeholder="https://your-site.com"
+                                    value={openApiBaseUrl}
+                                    onChange={(e) => setOpenApiBaseUrl(e.target.value)}
+                                />
+                            </div>
+                            <DialogFooter>
+                                <Button
+                                    variant="outline"
+                                    onClick={() => setOpenApiDialogOpen(false)}
+                                >
+                                    Cancel
+                                </Button>
+                                <Button
+                                    onClick={() => handleDownloadOpenAPI(openApiBaseUrl)}
+                                    disabled={openApiLoading}
+                                >
+                                    {openApiLoading ? "Downloading…" : "Download"}
+                                </Button>
+                            </DialogFooter>
+                        </DialogContent>
+                    </Dialog>
                     <Dialog>
                         <DialogTrigger asChild>
                             <Button aria-label="View Bench Commands" size={'sm'} variant={'outline'}>

--- a/dashboard/src/components/features/api_viewer/APIList.tsx
+++ b/dashboard/src/components/features/api_viewer/APIList.tsx
@@ -5,7 +5,8 @@ import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectVa
 import { APIData } from "@/types/APIData"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { CommandContent } from "../commands/CommandsContent"
-import { Box, GitBranch, SquareTerminal } from "lucide-react"
+import { Box, FileJson, GitBranch, SquareTerminal } from "lucide-react"
+import { web_url } from "@/config/socket"
 
 export interface APIListProps {
     apiList: APIData[]
@@ -15,11 +16,42 @@ export interface APIListProps {
     selectedEndpoint?: string
     path_to_folder: string
     listRef?: React.RefObject<HTMLDivElement>
+    /** 'app' = Installed Apps explorer; 'project' = Project Apps (Commit Project Branch) explorer */
+    viewerType?: 'app' | 'project'
+    /** Required when viewerType is 'project' – the Commit Project Branch document name */
+    project_branch?: string
 }
 
-const APIList = ({ apiList, app_name, branch_name, setSelectedEndpoint, selectedEndpoint, path_to_folder, listRef }: APIListProps) => {
+const APIList = ({ apiList, app_name, branch_name, setSelectedEndpoint, selectedEndpoint, path_to_folder, listRef, viewerType = 'app', project_branch }: APIListProps) => {
     const [searchQuery, setSearchQuery] = useState<string>('')
     const [requestTypeFilter, setRequestTypeFilter] = useState<string>('All')
+    const [openApiLoading, setOpenApiLoading] = useState(false)
+
+    const handleDownloadOpenAPI = async () => {
+        const isProject = viewerType === 'project' && project_branch
+        const method = isProject
+            ? 'commit.api.openapi.get_openapi_definition_project_apps'
+            : 'commit.api.openapi.get_openapi_definition_installed_apps'
+        const params: Record<string, string> = {}
+        if (isProject && project_branch) params.project_branch = project_branch
+        else if (app_name) params.app_name = app_name
+        const qs = new URLSearchParams(params).toString()
+        const url = `${web_url}/api/method/${method}${qs ? `?${qs}` : ''}`
+        setOpenApiLoading(true)
+        try {
+            const res = await fetch(url)
+            const json = await res.json()
+            const spec = json?.message ?? json
+            const blob = new Blob([JSON.stringify(spec, null, 2)], { type: 'application/json' })
+            const a = document.createElement('a')
+            a.href = URL.createObjectURL(blob)
+            a.download = `${app_name}-${project_branch}-openapi.json`
+            a.click()
+            URL.revokeObjectURL(a.href)
+        } finally {
+            setOpenApiLoading(false)
+        }
+    }
 
     const filterList = useMemo(() => {
 
@@ -60,15 +92,27 @@ const APIList = ({ apiList, app_name, branch_name, setSelectedEndpoint, selected
                         <p>{branch_name}</p>
                     </div>
                 </div>
-                <Dialog>
-                    <DialogTrigger asChild>
-                        <Button aria-label="View Bench Commands" size={'sm'} variant={'outline'}>
-                            <SquareTerminal className="h-4 w-4 mr-2" />
-                            Commands
-                        </Button>
-                    </DialogTrigger>
-                    <CommandContent app={app_name} app_path={path_to_folder} />
-                </Dialog>
+                <div className="flex items-center gap-1">
+                    <Button
+                        aria-label="Download OpenAPI spec"
+                        size="sm"
+                        variant="outline"
+                        onClick={handleDownloadOpenAPI}
+                        disabled={openApiLoading}
+                    >
+                        <FileJson className="h-4 w-4 mr-2" />
+                         OpenAPI
+                    </Button>
+                    <Dialog>
+                        <DialogTrigger asChild>
+                            <Button aria-label="View Bench Commands" size={'sm'} variant={'outline'}>
+                                <SquareTerminal className="h-4 w-4 mr-2" />
+                                Commands
+                            </Button>
+                        </DialogTrigger>
+                        <CommandContent app={app_name} app_path={path_to_folder} />
+                    </Dialog>
+                </div>
             </div>
             <div className="flex flex-row space-x-4">
                 <div className="w-4/5 flex flex-row space-x-4">

--- a/dashboard/src/pages/features/api_viewer/APIViewer.tsx
+++ b/dashboard/src/pages/features/api_viewer/APIViewer.tsx
@@ -94,6 +94,8 @@ export const APIViewer = ({ projectBranch }: { projectBranch: string }) => {
                             selectedEndpoint={selectedendpoint}
                             path_to_folder={data?.message.path_to_folder}
                             listRef={listRef}
+                            viewerType="project"
+                            project_branch={projectBranch}
                         />
                     </Suspense>
                 </div>

--- a/dashboard/src/pages/features/api_viewer/AppAPIViewer.tsx
+++ b/dashboard/src/pages/features/api_viewer/AppAPIViewer.tsx
@@ -82,6 +82,7 @@ export const AppAPIViewer = ({ appName }: { appName: string }) => {
                             selectedEndpoint={selectedendpoint}
                             path_to_folder=""
                             listRef={listRef}
+                            viewerType="app"
                         />
                     </Suspense>
 


### PR DESCRIPTION
# Add OpenAPI (Swagger) definition to Commit

Closes #90

## Summary

This PR adds a standards-based **OpenAPI 3.0** definition for Commit’s discovered APIs (whitelisted Frappe methods), exposed as downloadable specs and integrated into the API Explorer for both **Installed Apps** and **Project Apps**.

---

## What was solved

- **No standard API contract:** Previously, APIs were only discoverable via the API Explorer UI and Bruno files. There was no machine-readable, tooling-friendly spec.
- **Manual integration:** External systems, SDKs, and API gateways had no way to consume Commit’s API surface without manual work.
- **No single source of truth:** OpenAPI provides a single, consistent description of paths, methods, parameters, and auth for all whitelisted methods.

---

## What was implemented

### 1. Two separate OpenAPI endpoints

| Endpoint | Scope | Use case |
|----------|--------|----------|
| **Installed Apps** | `get_openapi_definition_installed_apps(app_name?)` | Whitelisted methods from apps on the current site (optionally filtered by `app_name`). |
| **Project Apps** | `get_openapi_definition_project_apps(project_branch?)` | Whitelisted methods from Commit Project Branch documents (optionally filtered by `project_branch`). |

- Both are **whitelisted** and **allow_guest**, so the spec can be fetched without auth if desired.
- Spec includes **paths** (`/api/method/<api_path>`), **parameters** (from function signatures), **request types** (GET/POST/etc.), **documentation**, and **security** (guest vs authenticated).

### 2. API Explorer integration

- **OpenAPI** button added beside the **Commands** button in the API Explorer (both Installed Apps and Project Apps).
- One click downloads the relevant OpenAPI JSON for the current app or project branch.
- No need to leave the Explorer to get a spec.


## Benefits

1. **SDK and client generation**  
   Use OpenAPI code generators (e.g. OpenAPI Generator, Swagger Codegen) to produce clients in Python, TypeScript, Java, etc., from the downloaded spec.

2. **Request validation and testing**  
   Tools like Schemathesis or Dredd can validate requests/responses against the spec; CI can run contract tests automatically.

3. **Easier integration with API gateways and external systems**  
   Gateways and third-party tools that expect OpenAPI can ingest the spec directly, improving interoperability outside the Frappe ecosystem.

4. **Better DX in Bruno / Postman / Swagger UI**  
   Import the spec once; all endpoints and parameters are available with correct base URL and unique operation names, reducing manual configuration.

5. **Single source of truth**  
   One spec per app or project branch that stays in sync with Commit’s discovery (whitelisted methods, parameters, docs).

---

## How to use

- **From API Explorer (Installed Apps):** Open an app’s API Explorer → click **OpenAPI** → `openapi.json` is downloaded for that app.
- **From API Explorer (Project Apps):** Open a project branch’s API Explorer → click **OpenAPI** → `openapi.json` is downloaded for that branch.
- **Via API:**  
  - Installed Apps: `GET /api/method/commit.api.openapi.get_openapi_definition_installed_apps?app_name=<app>`  
  - Project Apps: `GET /api/method/commit.api.openapi.get_openapi_definition_project_apps?project_branch=<branch>`
- **In Bruno / Postman / Swagger UI:** Import the downloaded JSON; base URL and operation names are set so you can send requests without manually setting baseUrl per request.

---